### PR TITLE
[N/A] commons-text 추가

### DIFF
--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -95,6 +95,11 @@
       <artifactId>commons-lang</artifactId>
       <version>${commons-lang.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${commons-text.version}</version>
+    </dependency>
     <!-- XXX we probably shouldn't be shipping this but the tests depend on it -->
     <dependency>
       <groupId>org.apache.derby</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-pool.version>1.5.4</commons-pool.version>
     <commons-dbcp.version>1.4</commons-dbcp.version>
+    <commons-text.version>1.8</commons-text.version>
     <derby.version>10.14.1.0</derby.version>
     <dropwizard.version>3.1.0</dropwizard.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2</dropwizard-metrics-hadoop-metrics2-reporter.version>
@@ -332,6 +333,11 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>${commons-lang.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${commons-text.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
hive 패치로 인한 runtime시 common-text 파일이 필요
- 기존 도커 이미지 업그레이드가 아닌 7.2.0-SNAPSHOT 설치시 발생
`2024-01-23T04:36:38,378 ERROR [main] metastore.RetryingHMSHandler: java.lang.NoSuchMethodError: org.apache.commons.text.lookup.StringLookupFactory.base64DecoderStringLookup()Lorg/apache/commons/text/lookup/StringLookup;
        at org.apache.commons.configuration2.interpol.DefaultLookups.<clinit>(DefaultLookups.java:68)
        at org.apache.commons.configuration2.interpol.ConfigurationInterpolator$DefaultPrefixLookupsHolder.createDefaultLookups(ConfigurationInterpolator.java:647)
        at org.apache.commons.configuration2.interpol.ConfigurationInterpolator$DefaultPrefixLookupsHolder.<init>(ConfigurationInterpolator.java:627)
        at org.apache.commons.configuration2.interpol.ConfigurationInterpolator$DefaultPrefixLookupsHolder.<clinit>(ConfigurationInterpolator.java:614)
        at org.apache.commons.configuration2.interpol.ConfigurationInterpolator.getDefaultPrefixLookups(ConfigurationInterpolator.java:290)
        at org.apache.commons.configuration2.AbstractConfiguration.installDefaultInterpolator(AbstractConfiguration.java:375)
        at org.apache.commons.configuration2.AbstractConfiguration.<init>(AbstractConfiguration.java:122)
        at org.apache.commons.configuration2.BaseConfiguration.<init>(BaseConfiguration.java:37)
        at org.apache.commons.configuration2.PropertiesConfiguration.<init>(PropertiesConfiguration.java:1059)
        at org.apache.hadoop.metrics2.impl.MetricsConfig.loadFirst(MetricsConfig.java:114)
        at org.apache.hadoop.metrics2.impl.MetricsConfig.create(MetricsConfig.java:97)
        at org.apache.hadoop.metrics2.impl.MetricsSystemImpl.configure(MetricsSystemImpl.java:482)
        at org.apache.hadoop.metrics2.impl.MetricsSystemImpl.start(MetricsSystemImpl.java:188)
        at org.apache.hadoop.metrics2.impl.MetricsSystemImpl.init(MetricsSystemImpl.java:163)
        at org.apache.hadoop.fs.s3a.S3AInstrumentation.getMetricsSystem(S3AInstrumentation.java:249)
        at org.apache.hadoop.fs.s3a.S3AInstrumentation.registerAsMetricsSource(S3AInstrumentation.java:272)
        at org.apache.hadoop.fs.s3a.S3AInstrumentation.<init>(S3AInstrumentation.java:229)
        at org.apache.hadoop.fs.s3a.S3AFileSystem.initialize(S3AFileSystem.java:519)
        at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3611)
        at org.apache.hadoop.fs.FileSystem.access$300(FileSystem.java:174)
        at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3712)
        at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3663)
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:557)
        at org.apache.hadoop.fs.Path.getFileSystem(Path.java:365)
        at org.apache.hadoop.hive.metastore.Warehouse.getFs(Warehouse.java:115)
        at org.apache.hadoop.hive.metastore.Warehouse.getDnsPath(Warehouse.java:141)
        at org.apache.hadoop.hive.metastore.Warehouse.getDnsPath(Warehouse.java:147)
        at org.apache.hadoop.hive.metastore.Warehouse.getWhRoot(Warehouse.java:160)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.createDefaultCatalog(HiveMetaStore.java:733)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.createDefaultDB(HiveMetaStore.java:770)
        at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.init(HiveMetaStore.java:540)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invokeInternal(RetryingHMSHandler.java:147)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invoke(RetryingHMSHandler.java:108)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.<init>(RetryingHMSHandler.java:80)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.getProxy(RetryingHMSHandler.java:93)
        at org.apache.hadoop.hive.metastore.HiveMetaStore.newRetryingHMSHandler(HiveMetaStore.java:8673)
        at org.apache.hadoop.hive.metastore.HiveMetaStore.newRetryingHMSHandler(HiveMetaStore.java:8668)
        at org.apache.hadoop.hive.metastore.HiveMetaStore.startMetaStore(HiveMetaStore.java:8938)
        at org.apache.hadoop.hive.metastore.HiveMetaStore.main(HiveMetaStore.java:8855)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.hadoop.util.RunJar.run(RunJar.java:328)
        at org.apache.hadoop.util.RunJar.main(RunJar.java:241)
`